### PR TITLE
Revert "Refactoring count methods to use lambdas"

### DIFF
--- a/src/main/kotlin/controllers/NoteAPI.kt
+++ b/src/main/kotlin/controllers/NoteAPI.kt
@@ -63,25 +63,23 @@ class NoteAPI(serializerType: Serializer) {
 }
 
     fun numberOfArchivedNotes(): Int {
-       return notes.stream()
-           .filter{note: Note -> note.isNoteArchived}
-           .count()
-           .toInt()
+        var counter = 0
+        for (note in notes) {
+            if (note.isNoteArchived){
+                counter++
+            }
+        }
+        return counter
     }
-
 
     fun numberOfActiveNotes(): Int {
-        return notes.stream()
-            .filter{note: Note -> !note.isNoteArchived}
-            .count()
-            .toInt()
-    }
-
-    fun numberOfNotesByPriority(priority: Int): Int {
-        return notes.stream()
-            .filter{note: Note -> note.notePriority == priority}
-            .count()
-            .toInt()
+        var counter = 0
+        for (note in notes) {
+            if (!note.isNoteArchived){
+                counter++
+            }
+        }
+        return counter
     }
 
     fun listNotesBySelectedPriority(priority: Int): String {
@@ -104,7 +102,15 @@ class NoteAPI(serializerType: Serializer) {
         }
     }
 
-
+    fun numberOfNotesByPriority(priority: Int): Int {
+        var counter = 0
+        for (note in notes) {
+            if (note.notePriority == priority) {
+                counter++
+            }
+        }
+        return counter
+    }
 
     /*fun listNotesByCategory(category : String): String {
         return if (notes.isEmpty()) {

--- a/src/test/kotlin/controllers/NoteAPITest.kt
+++ b/src/test/kotlin/controllers/NoteAPITest.kt
@@ -306,36 +306,4 @@ class NoteAPITest {
             assertEquals(true, populatedNotes!!.findNote(3)!!.isNoteArchived)
         }
     }
-
-    @Nested
-    inner class CountingMethods {
-
-        @Test
-        fun numberOfNotesCalculatedCorrectly() {
-            assertEquals(5, populatedNotes!!.numberOfNotes())
-            assertEquals(0, emptyNotes!!.numberOfNotes())
-        }
-
-        @Test
-        fun numberOfArchivedNotesCalculatedCorrectly() {
-            assertEquals(2, populatedNotes!!.numberOfArchivedNotes())
-            assertEquals(0, emptyNotes!!.numberOfArchivedNotes())
-        }
-
-        @Test
-        fun numberOfActiveNotesCalculatedCorrectly() {
-            assertEquals(3, populatedNotes!!.numberOfActiveNotes())
-            assertEquals(0, emptyNotes!!.numberOfActiveNotes())
-        }
-
-        @Test
-        fun numberOfNotesByPriorityCalculatedCorrectly() {
-            assertEquals(1, populatedNotes!!.numberOfNotesByPriority(1))
-            assertEquals(0, populatedNotes!!.numberOfNotesByPriority(2))
-            assertEquals(1, populatedNotes!!.numberOfNotesByPriority(3))
-            assertEquals(2, populatedNotes!!.numberOfNotesByPriority(4))
-            assertEquals(1, populatedNotes!!.numberOfNotesByPriority(5))
-            assertEquals(0, emptyNotes!!.numberOfNotesByPriority(1))
-        }
-    }
 }


### PR DESCRIPTION
Count methods were refactored to use lambdas.

This pull request is linked to issue #20  and automatically closes #20  when merged.