### PR TITLE
Refactoring to use one method to format and count

### DIFF
--- a/src/main/kotlin/controllers/NoteAPI.kt
+++ b/src/main/kotlin/controllers/NoteAPI.kt
@@ -9,7 +9,11 @@ class NoteAPI(serializerType: Serializer) {
     }
 
 
-
+private fun formatListString(notesToFormat : List<Note>): String =
+    notesToFormat
+        .joinToString (separator = "\n") { note ->
+            notes.indexOf(note).toString() + ": "+ note.toString()
+        }
     fun numberOfNotes(): Int {
         return notes.size
     }
@@ -29,10 +33,8 @@ class NoteAPI(serializerType: Serializer) {
     }
 
     fun searchByTitle(searchString: String) =
-        notes.filter {note -> note.noteTitle.contains(searchString, ignoreCase = true)}
-            .joinToString( separator = "/n"){note ->
-                notes.indexOf(note).toString()+":"+note.toString()
-            }
+        formatListString(
+            notes.filter {note -> note.noteTitle.contains(searchString, ignoreCase = true)} )
 
     /*fun searchByPriority(index: Int): Note?{
         return
@@ -42,28 +44,21 @@ class NoteAPI(serializerType: Serializer) {
           if (notes.isEmpty())
              "No notes stored"
          else
-            notes.joinToString (separator = "\n"){ note ->
-                notes.indexOf(note).toString() + ":" + note.toString()
-
-        }
+            formatListString(notes)
 
     fun listActiveNotes(): String =
         if (numberOfActiveNotes() == 0 )
             "No active notes stored"
          else
-            notes.filter {note -> note.isNoteArchived == false}
-            .joinToString (separator = "\n"){ note ->
-                notes.indexOf(note).toString() + ":" + note.toString()
-    }
+            formatListString(notes.filter {note -> note.isNoteArchived == false})
+
 
     fun listArchivedNotes(): String =
          if (numberOfArchivedNotes() == 0)
             "No archived notes stored"
          else
-             notes.filter {note -> note.isNoteArchived == true}
-                 .joinToString (separator = "\n"){ note ->
-                     notes.indexOf(note).toString() + ":" + note.toString()
-    }
+             formatListString(notes.filter {note -> note.isNoteArchived == true})
+
 
     fun listNotesBySelectedPriority(priority: Int): String =
          if (notes.isEmpty())
@@ -84,26 +79,16 @@ class NoteAPI(serializerType: Serializer) {
                  "${numberOfNotesByPriority(priority)} notes with priority $priority: $listOfNotes"
              }
          }
-    fun numberOfArchivedNotes(): Int {
-        return notes.stream()
-            .filter { note: Note -> note.isNoteArchived }
-            .count()
-            .toInt()
-    }
+    fun numberOfArchivedNotes(): Int =
+        notes.count { note: Note -> note.isNoteArchived }
 
-    fun numberOfActiveNotes(): Int {
-        return notes.stream()
-            .filter{note: Note -> !note.isNoteArchived}
-            .count()
-            .toInt()
-    }
 
-    fun numberOfNotesByPriority(priority: Int): Int {
-        return notes.stream()
-            .filter{note: Note -> note.notePriority == priority}
-            .count()
-            .toInt()
-    }
+    fun numberOfActiveNotes(): Int =
+        notes.count {note: Note -> !note.isNoteArchived}
+
+
+    fun numberOfNotesByPriority(priority: Int): Int =
+        notes.count {note: Note -> note.notePriority == priority}
 
 
     /*fun listNotesByCategory(category : String): String {


### PR DESCRIPTION
Refactored the list methods to use one function for formatting to a string. 
and refactored the count methods to be a single expression.

This pull request is linked to issue #29 and automatically closes #29 when merged.

